### PR TITLE
Make sky depth infinite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ configurations {
 }
 
 dependencies {
-    provided 'se.llbit:chunky-core:2.4.4'
+    provided 'se.llbit:chunky-core:2.4.2'
     provided 'org.apache.commons:commons-math3:3.2'
     provided 'it.unimi.dsi:fastutil:8.4.4'
     bundled 'org.jocl:jocl:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,14 @@ configurations {
 }
 
 dependencies {
-    provided 'se.llbit:chunky-core:2.4.2'
+    provided 'se.llbit:chunky-core:2.4.4'
     provided 'org.apache.commons:commons-math3:3.2'
     provided 'it.unimi.dsi:fastutil:8.4.4'
     bundled 'org.jocl:jocl:2.0.2'
 }
 
 javafx {
-    version = '11'
+    version = '11.0.2'
     modules = ['javafx.base', 'javafx.controls', 'javafx.fxml']
     configuration = 'provided'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 }
 
 javafx {
-    version = '11.0.2'
+    version = '11'
     modules = ['javafx.base', 'javafx.controls', 'javafx.fxml']
     configuration = 'provided'
 }

--- a/src/main/java/dev/thatredox/chunkyaov/raytracer/DepthTracer.java
+++ b/src/main/java/dev/thatredox/chunkyaov/raytracer/DepthTracer.java
@@ -29,6 +29,7 @@ import se.llbit.math.Ray;
 
 public class DepthTracer implements RayTracer {
     public static double NORMALIZATION_FACTOR = 100.0;
+    public static boolean INFINITE_SKY_DISTANCE = true;
 
     private DepthTracer() {}
 
@@ -50,7 +51,8 @@ public class DepthTracer implements RayTracer {
     @Override
     public void trace(Scene scene, WorkerState state) {
         Ray ray = state.ray;
-        double distance = 0.0;
+        double distance = INFINITE_SKY_DISTANCE ? Double.longBitsToDouble(0x7fe0000000000000L) : 0.0;
+
         if (PreviewRayTracer.nextIntersection(scene, ray)) {
             distance = ray.distance;
         }

--- a/src/main/java/dev/thatredox/chunkyaov/raytracer/DepthTracer.java
+++ b/src/main/java/dev/thatredox/chunkyaov/raytracer/DepthTracer.java
@@ -51,7 +51,7 @@ public class DepthTracer implements RayTracer {
     @Override
     public void trace(Scene scene, WorkerState state) {
         Ray ray = state.ray;
-        double distance = INFINITE_SKY_DISTANCE ? Double.longBitsToDouble(0x7fe0000000000000L) : 0.0;
+        double distance = INFINITE_SKY_DISTANCE ? Double.MAX_VALUE : 0.0;
 
         if (PreviewRayTracer.nextIntersection(scene, ray)) {
             distance = ray.distance;

--- a/src/main/java/dev/thatredox/chunkyaov/ui/ChunkyAovTab.java
+++ b/src/main/java/dev/thatredox/chunkyaov/ui/ChunkyAovTab.java
@@ -40,6 +40,7 @@ public class ChunkyAovTab implements RenderControlsTab {
     private final SimpleBooleanProperty nmPositive = new SimpleBooleanProperty(NormalTracer.MAP_POSITIVE);
     private final SimpleBooleanProperty nmWaterDisplacement = new SimpleBooleanProperty(NormalTracer.WATER_DISPLACEMENT);
     private final SimpleDoubleProperty depthNormFactor = new SimpleDoubleProperty(DepthTracer.NORMALIZATION_FACTOR);
+    private final SimpleBooleanProperty infiniteSkyDepth = new SimpleBooleanProperty(DepthTracer.INFINITE_SKY_DISTANCE);
 
     public ChunkyAovTab() {
         nmPositive.addListener((observable, oldValue, newValue) -> {
@@ -61,6 +62,13 @@ public class ChunkyAovTab implements RenderControlsTab {
             DepthTracer.NORMALIZATION_FACTOR = value;
             if (scene != null) {
                 scene.setAdditionalData("aov_depth_normalization", Json.of(value));
+                scene.refresh();
+            }
+        });
+        infiniteSkyDepth.addListener((observable, oldValue, newValue) -> {
+            DepthTracer.INFINITE_SKY_DISTANCE = newValue;
+            if (scene != null) {
+                scene.setAdditionalData("aov_infinite_sky_depth", Json.of(newValue));
                 scene.refresh();
             }
         });
@@ -86,6 +94,10 @@ public class ChunkyAovTab implements RenderControlsTab {
         depthNormAdjuster.setRange(1.0, 1000.0);
         depthNormAdjuster.clampMin();
         box.getChildren().add(depthNormAdjuster);
+
+        CheckBox enableInfiniteSkyDepth = new CheckBox("Infinite Sky Depth");
+        enableInfiniteSkyDepth.selectedProperty().bindBidirectional(infiniteSkyDepth);
+        box.getChildren().add(enableInfiniteSkyDepth);
     }
 
     @Override
@@ -94,6 +106,7 @@ public class ChunkyAovTab implements RenderControlsTab {
         nmPositive.set(scene.getAdditionalData("aov_normal_positive").boolValue(nmPositive.get()));
         nmWaterDisplacement.set(scene.getAdditionalData("aov_normal_water_displacement").boolValue(nmWaterDisplacement.get()));
         depthNormFactor.set(scene.getAdditionalData("aov_depth_normalization").doubleValue(depthNormFactor.get()));
+        infiniteSkyDepth.set(scene.getAdditionalData("aov_infinite_sky_depth").boolValue(infiniteSkyDepth.get()));
     }
 
     @Override

--- a/src/main/java/dev/thatredox/chunkyaov/ui/ChunkyAovTab.java
+++ b/src/main/java/dev/thatredox/chunkyaov/ui/ChunkyAovTab.java
@@ -28,6 +28,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.Separator;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.ui.DoubleAdjuster;
 import se.llbit.chunky.ui.SliderAdjuster;
@@ -98,6 +99,12 @@ public class ChunkyAovTab implements RenderControlsTab {
         CheckBox enableInfiniteSkyDepth = new CheckBox("Infinite Sky Depth");
         enableInfiniteSkyDepth.selectedProperty().bindBidirectional(infiniteSkyDepth);
         box.getChildren().add(enableInfiniteSkyDepth);
+
+        box.getChildren().add(new Separator());
+
+        Text text = new Text("For accurate results, set the Postprocessing filter in the Postprocessing tab to None.");
+        text.setWrappingWidth(350);
+        box.getChildren().add(text);
     }
 
     @Override

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -2,7 +2,7 @@
     "name": "Chunky AOV",
     "author": "Redox",
     "main": "dev.thatredox.chunkyaov.ChunkyAOV",
-    "version": "0.0.1",
-    "targetVersion": "2.4.2",
+    "version": "0.0.2",
+    "targetVersion": "2.4.4",
     "description": "Arbitrary output variable renderers for Chunky."
 }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -3,6 +3,6 @@
     "author": "Redox",
     "main": "dev.thatredox.chunkyaov.ChunkyAOV",
     "version": "0.0.2",
-    "targetVersion": "2.4.4",
+    "targetVersion": "2.4.2",
     "description": "Arbitrary output variable renderers for Chunky."
 }


### PR DESCRIPTION
Fixes #1.
This can be enabled and disabled with a control in the plugin tab.

![image](https://user-images.githubusercontent.com/92183530/197593322-ce20b793-eae2-4b46-952f-33a87050f53b.png)
